### PR TITLE
Update README to include Fess snapshot-noble configurations with OpenSearch 2 and 3

### DIFF
--- a/.github/workflows/run-fessx-noble-opensearch2.yml
+++ b/.github/workflows/run-fessx-noble-opensearch2.yml
@@ -1,0 +1,22 @@
+name: run-fessx-noble-opensearch2
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 4'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fessx-noble opensearch2

--- a/.github/workflows/run-fessx-noble-opensearch3.yml
+++ b/.github/workflows/run-fessx-noble-opensearch3.yml
@@ -1,0 +1,22 @@
+name: run-fessx-noble-opensearch3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 2'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fessx-noble opensearch3

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@
 | [![run-fess14x-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess14x-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess14x-opensearch2.yml) | Fess 14.x | OpenSearch 2 |
 | [![run-fessx-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch2.yml) | Fess (snapshot-deb) | OpenSearch 2 |
 | [![run-fessx-al2023-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch2.yml) | Fess (snapshot-rpm) | OpenSearch 2 |
-| [![run-fessx-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch3.yml) | Fess (snapshot-deb) | OpenSearch 2 |
-| [![run-fessx-al2023-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml) | Fess (snapshot-rpm) | OpenSearch 2 |
+| [![run-fessx-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-opensearch3.yml) | Fess (snapshot-deb) | OpenSearch 3 |
+| [![run-fessx-al2023-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml) | Fess (snapshot-rpm) | OpenSearch 3 |
+| [![run-fessx-noble-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch2.yml) | Fess (snapshot-noble) | OpenSearch 2 |
+| [![run-fessx-noble-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch3.yml) | Fess (snapshot-noble) | OpenSearch 3 |
 
 ## Usage
 

--- a/compose-fessx-noble.yaml
+++ b/compose-fessx-noble.yaml
@@ -1,0 +1,13 @@
+services:
+  fesstest01:
+    image: ghcr.io/codelibs/fess:snapshot-noble
+    container_name: fesstest01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/elasticsearch/config/dictionary/}"
+#    ports:
+#      - "8080:8080"
+    networks:
+      - searchtestnet
+    depends_on:
+      - searchtest01


### PR DESCRIPTION
This update modifies the README.md to:

- Correctly reflect that fessx-opensearch3 and fessx-al2023-opensearch3 use OpenSearch 3 instead of OpenSearch 2.
- Add badges and descriptions for two new test workflows:
- fessx-noble with OpenSearch 2
- fessx-noble with OpenSearch 3

These changes improve documentation accuracy and provide visibility into the test coverage for the new Fess snapshot-noble environments.
