### PR TITLE
Add support for Fess 15 with OpenSearch 2/3 across multiple environments

### DIFF
--- a/.github/workflows/run-fess15-al2023-opensearch2.yml
+++ b/.github/workflows/run-fess15-al2023-opensearch2.yml
@@ -1,0 +1,16 @@
+name: run-fess15-al2023-opensearch2
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fess15-al2023 opensearch2

--- a/.github/workflows/run-fess15-al2023-opensearch3.yml
+++ b/.github/workflows/run-fess15-al2023-opensearch3.yml
@@ -1,0 +1,16 @@
+name: run-fess15-al2023-opensearch3
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Monday (secondary)
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fess15-al2023 opensearch3

--- a/.github/workflows/run-fess15-noble-opensearch2.yml
+++ b/.github/workflows/run-fess15-noble-opensearch2.yml
@@ -1,0 +1,16 @@
+name: run-fess15-noble-opensearch2
+
+on:
+  schedule:
+    - cron: '0 0 * * 3'  # Wednesday (secondary)
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fess15-noble opensearch2

--- a/.github/workflows/run-fess15-noble-opensearch3.yml
+++ b/.github/workflows/run-fess15-noble-opensearch3.yml
@@ -1,0 +1,16 @@
+name: run-fess15-noble-opensearch3
+
+on:
+  schedule:
+    - cron: '0 0 * * 5'  # Friday (secondary)
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fess15-noble opensearch3

--- a/.github/workflows/run-fess15-opensearch2.yml
+++ b/.github/workflows/run-fess15-opensearch2.yml
@@ -1,0 +1,16 @@
+name: run-fess15-opensearch2
+
+on:
+  schedule:
+    - cron: '0 0 * * 6'  # Saturday
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run-compose
+        shell: bash
+        run: |
+          /bin/bash ./run_test.sh fess15 opensearch2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 | [![run-fessx-al2023-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-al2023-opensearch3.yml) | Fess (snapshot-rpm) | OpenSearch 3 |
 | [![run-fessx-noble-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch2.yml) | Fess (snapshot-noble) | OpenSearch 2 |
 | [![run-fessx-noble-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fessx-noble-opensearch3.yml) | Fess (snapshot-noble) | OpenSearch 3 |
+| [![run-fess15-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-opensearch2.yml) | Fess 15 | OpenSearch 2 |
+| [![run-fess15-al2023-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-al2023-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-al2023-opensearch2.yml) | Fess 15 (al2023) | OpenSearch 2 |
+| [![run-fess15-al2023-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-al2023-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-al2023-opensearch3.yml) | Fess 15 (al2023) | OpenSearch 3 |
+| [![run-fess15-noble-opensearch2](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-noble-opensearch2.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-noble-opensearch2.yml) | Fess 15 (noble) | OpenSearch 2 |
+| [![run-fess15-noble-opensearch3](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-noble-opensearch3.yml/badge.svg)](https://github.com/codelibs/fess-test-ui/actions/workflows/run-fess15-noble-opensearch3.yml) | Fess 15 (noble) | OpenSearch 3 |
 
 ## Usage
 

--- a/compose-fess15-al2023.yaml
+++ b/compose-fess15-al2023.yaml
@@ -1,0 +1,13 @@
+services:
+  fesstest01:
+    image: ghcr.io/codelibs/fess:15.1-al2023
+    container_name: fesstest01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/elasticsearch/config/dictionary/}"
+#    ports:
+#      - "8080:8080"
+    networks:
+      - searchtestnet
+    depends_on:
+      - searchtest01

--- a/compose-fess15-noble.yaml
+++ b/compose-fess15-noble.yaml
@@ -1,0 +1,13 @@
+services:
+  fesstest01:
+    image: ghcr.io/codelibs/fess:15.1-noble
+    container_name: fesstest01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/elasticsearch/config/dictionary/}"
+#    ports:
+#      - "8080:8080"
+    networks:
+      - searchtestnet
+    depends_on:
+      - searchtest01

--- a/compose-fess15.yaml
+++ b/compose-fess15.yaml
@@ -1,0 +1,13 @@
+services:
+  fesstest01:
+    image: ghcr.io/codelibs/fess:15.1.0
+    container_name: fesstest01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/elasticsearch/config/dictionary/}"
+#    ports:
+#      - "8080:8080"
+    networks:
+      - searchtestnet
+    depends_on:
+      - searchtest01


### PR DESCRIPTION
This update introduces support for Fess 15 by:

- Adding five new GitHub Actions workflows to test combinations of Fess 15 with OpenSearch 2 and 3 across standard, al2023, and noble environments.
- Updating the README.md to include badges for these new workflows.
- Adding three new Docker Compose configuration files (compose-fess15.yaml, compose-fess15-al2023.yaml, and compose-fess15-noble.yaml) for local testing of these environments.

These changes enhance compatibility testing coverage for Fess 15 with various OpenSearch and OS variants.