### PR TITLE
Update Fess Docker image tags to explicit version 15.1.0

### DIFF
--- a/compose-fess15-al2023.yaml
+++ b/compose-fess15-al2023.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.1-al2023
+    image: ghcr.io/codelibs/fess:15.1.0-al2023
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15-noble.yaml
+++ b/compose-fess15-noble.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.1-noble
+    image: ghcr.io/codelibs/fess:15.1.0-noble
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"


### PR DESCRIPTION
This pull request updates the Docker image tags in compose-fess15-al2023.yaml and compose-fess15-noble.yaml from a floating version (15.1-al2023 / 15.1-noble) to a specific version 15.1.0-al2023 and 15.1.0-noble, respectively.
Pinning explicit versions improves reproducibility and stability of container builds by avoiding unintended updates.