### PR TITLE
chore(deps): upgrade OpenSearch to version 3.6.0

### DIFF
--- a/compose-opensearch3.yaml
+++ b/compose-opensearch3.yaml
@@ -1,6 +1,6 @@
 services:
   searchtest01:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: searchtest01
     environment:
       - node.name=searchtest01


### PR DESCRIPTION
## Summary
Upgrade OpenSearch Docker image from 3.5.0 to 3.6.0 for the OpenSearch 3 test configuration.

## Changes Made
- Updated `compose-opensearch3.yaml`: bumped `ghcr.io/codelibs/fess-opensearch` image tag from `3.5.0` to `3.6.0`

## Testing
- Run test suite with OpenSearch 3 configuration: `./run_test.sh fess15 opensearch3`

## Breaking Changes
- None

## Additional Notes
- Follows the established dependency upgrade pattern in this repository