### PR TITLE
chore(deps): upgrade Fess to version 15.6.0

### DIFF
--- a/compose-fess15-al2023.yaml
+++ b/compose-fess15-al2023.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.5.1-al2023
+    image: ghcr.io/codelibs/fess:15.6.0-al2023
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15-noble.yaml
+++ b/compose-fess15-noble.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.5.1-noble
+    image: ghcr.io/codelibs/fess:15.6.0-noble
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15.yaml
+++ b/compose-fess15.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.5.1
+    image: ghcr.io/codelibs/fess:15.6.0
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"


### PR DESCRIPTION
## Summary
Upgrade the Fess container image from 15.5.1 to 15.6.0 across all three Fess 15 compose variants used by the test matrix.

## Changes Made
- `compose-fess15.yaml`: bump `fesstest01` image to `ghcr.io/codelibs/fess:15.6.0`
- `compose-fess15-al2023.yaml`: bump `fesstest01` image to `ghcr.io/codelibs/fess:15.6.0-al2023`
- `compose-fess15-noble.yaml`: bump `fesstest01` image to `ghcr.io/codelibs/fess:15.6.0-noble`

## Testing
- CI workflows (`run-fess15*.yml`) will exercise each variant against the OpenSearch matrix on their weekly schedule or via `workflow_dispatch`.
- Locally: `./run_test.sh fess15 opensearch3` (and the `-al2023` / `-noble` counterparts) to run the Playwright admin-UI suite against the new image.

## Breaking Changes
- None expected. Image tag bump only; the admin-UI contract used by the tests is unchanged between 15.5.1 and 15.6.0.

## Additional Notes
- Follows the same pattern as #36 and #37. No code changes in `src/` are needed for this bump.
- Untracked files in the working tree (`COMPLETE_IMPROVEMENTS_GUIDE.md`, `PHASE1_IMPROVEMENTS.md`, `TEST_IMPROVEMENTS_SUMMARY.md`, `update_workflows.py`) are intentionally excluded from this PR — they are unrelated work-in-progress.