### PR TITLE
E2E coverage PR-4: admin read-only modules (final)

### DIFF
--- a/src/fess/test/ui/admin/general/pagedesign.py
+++ b/src/fess/test/ui/admin/general/pagedesign.py
@@ -1,0 +1,46 @@
+"""Verify /admin/design/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/design/"
+EXPECTED_MARKERS = ["ページのデザイン", "ファイルマネージャー"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting pagedesign")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"pagedesign completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/general/plugin.py
+++ b/src/fess/test/ui/admin/general/plugin.py
@@ -1,0 +1,46 @@
+"""Verify /admin/plugin/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/plugin/"
+EXPECTED_MARKERS = ["プラグイン", "Plugin"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting plugin")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"plugin completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/general/storage.py
+++ b/src/fess/test/ui/admin/general/storage.py
@@ -1,0 +1,46 @@
+"""Verify /admin/storage/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/storage/"
+EXPECTED_MARKERS = ["ストレージ", "Storage", "MinIO"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting storage")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"storage completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/backup.py
+++ b/src/fess/test/ui/admin/sysinfo/backup.py
@@ -1,0 +1,40 @@
+"""Verify /admin/backup/ page renders with expected structure."""
+import logging
+from playwright.sync_api import Playwright, sync_playwright
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/backup/"
+EXPECTED_MARKERS = ["バックアップ", "バルクファイル"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting backup")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+    logger.info(f"backup completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try: run(context)
+        finally: destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/configinfo.py
+++ b/src/fess/test/ui/admin/sysinfo/configinfo.py
@@ -1,0 +1,40 @@
+"""Verify /admin/systeminfo/ page renders with expected structure."""
+import logging
+from playwright.sync_api import Playwright, sync_playwright
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/systeminfo/"
+EXPECTED_MARKERS = ["システム情報", "アプリのプロパティ"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting configinfo")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+    logger.info(f"configinfo completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try: run(context)
+        finally: destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/crawlinfo.py
+++ b/src/fess/test/ui/admin/sysinfo/crawlinfo.py
@@ -1,0 +1,46 @@
+"""Verify /admin/crawlinginfo/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/crawlinginfo/"
+EXPECTED_MARKERS = ["クロール情報", "登録されていません。"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting crawlinfo")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"crawlinfo completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/failureurl.py
+++ b/src/fess/test/ui/admin/sysinfo/failureurl.py
@@ -1,0 +1,46 @@
+"""Verify /admin/failureurl/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/failureurl/"
+EXPECTED_MARKERS = ["エラー回数", "種別"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting failureurl")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"failureurl completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/joblog.py
+++ b/src/fess/test/ui/admin/sysinfo/joblog.py
@@ -1,0 +1,46 @@
+"""Verify /admin/joblog/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/joblog/"
+EXPECTED_MARKERS = ["ジョブログ", "一覧"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting joblog")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"joblog completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/logfile.py
+++ b/src/fess/test/ui/admin/sysinfo/logfile.py
@@ -1,0 +1,40 @@
+"""Verify /admin/log/ page renders with expected structure."""
+import logging
+from playwright.sync_api import Playwright, sync_playwright
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/log/"
+EXPECTED_MARKERS = ["ログファイル", "一覧"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting logfile")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+    logger.info(f"logfile completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try: run(context)
+        finally: destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/maintenance.py
+++ b/src/fess/test/ui/admin/sysinfo/maintenance.py
@@ -1,0 +1,40 @@
+"""Verify /admin/maintenance/ page renders with expected structure."""
+import logging
+from playwright.sync_api import Playwright, sync_playwright
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/maintenance/"
+EXPECTED_MARKERS = ["メンテナンス", "再インデクシング"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting maintenance")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+    logger.info(f"maintenance completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try: run(context)
+        finally: destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/searchlist.py
+++ b/src/fess/test/ui/admin/sysinfo/searchlist.py
@@ -1,0 +1,46 @@
+"""Verify /admin/searchlist/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/searchlist/"
+EXPECTED_MARKERS = ["新規作成", "検索"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting searchlist")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"searchlist completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/admin/sysinfo/searchlog.py
+++ b/src/fess/test/ui/admin/sysinfo/searchlog.py
@@ -1,0 +1,46 @@
+"""Verify /admin/searchlog/ page renders with expected structure."""
+import logging
+
+from playwright.sync_api import Playwright, sync_playwright
+
+from fess.test import assert_true
+from fess.test.ui import FessContext
+
+logger = logging.getLogger(__name__)
+
+PAGE_URL = "/admin/searchlog/"
+EXPECTED_MARKERS = ["クエリーID", "アクセスタイプ"]
+
+
+def setup(playwright: Playwright) -> FessContext:
+    context: FessContext = FessContext(playwright)
+    context.login()
+    return context
+
+
+def destroy(context: FessContext) -> None:
+    context.close()
+
+
+def run(context: FessContext) -> None:
+    logger.info("Starting searchlog")
+    page = context.get_admin_page()
+    page.goto(context.url(PAGE_URL))
+    page.wait_for_load_state("domcontentloaded")
+
+    body = page.inner_text("body")
+    matched = [m for m in EXPECTED_MARKERS if m in body]
+    assert_true(len(matched) > 0,
+                f"none of {EXPECTED_MARKERS} found in body; first 300 chars: {body[:300]}")
+
+    logger.info(f"searchlog completed (matched: {matched})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    with sync_playwright() as playwright:
+        context = setup(playwright)
+        try:
+            run(context)
+        finally:
+            destroy(context)

--- a/src/fess/test/ui/search/seed.py
+++ b/src/fess/test/ui/search/seed.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 SAMPLEDATA_URL = os.environ.get("SAMPLEDATA_URL", "http://sampledata01/")
 SEED_MIN_DOCS = int(os.environ.get("SEED_MIN_DOCS", "20"))
-SEED_READY_TIMEOUT = int(os.environ.get("SEED_READY_TIMEOUT", "180"))
+SEED_READY_TIMEOUT = int(os.environ.get("SEED_READY_TIMEOUT", "300"))
 SEED_POLL_INTERVAL = int(os.environ.get("SEED_POLL_INTERVAL", "2"))
 
 WEBCONFIG_NAME = "sampledata-e2e"
@@ -83,7 +83,7 @@ def _create_webconfig(page, context: FessContext) -> None:
     page.fill("textarea[name=\"excludedUrls\"]",
               "(?i).*(css|js|jpeg|jpg|gif|png|bmp|wmv|xml|ico)")
     page.fill("input[name=\"maxAccessCount\"]", "100")
-    page.fill("input[name=\"numOfThread\"]", "2")
+    page.fill("input[name=\"numOfThread\"]", "5")
     page.fill("textarea[name=\"description\"]", "E2E sampledata (managed by search/seed)")
 
     # Attach both labels. The labelTypeIds select is hidden by display:none in

--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,20 @@ from fess.test.ui.admin import (accesstoken,
                                 webconfig,
                                 fileconfig)
 
-from fess.test.ui.admin.general import popularWord
+from fess.test.ui.admin.general import (popularWord,
+                                        pagedesign,
+                                        storage,
+                                        plugin)
+
+from fess.test.ui.admin.sysinfo import (backup,
+                                        configinfo,
+                                        crawlinfo,
+                                        failureurl,
+                                        joblog,
+                                        logfile,
+                                        maintenance,
+                                        searchlist,
+                                        searchlog)
 
 from fess.test.ui.admin.dict import (kuromoji,
                                      protwords,
@@ -115,6 +128,20 @@ def get_modules_to_run() -> List[Any]:
         'search_suggest': search_suggest,
         'search_related': search_related,
         'popularWord': popularWord,
+        # Admin read-only: general sub-pages
+        'pagedesign': pagedesign,
+        'storage': storage,
+        'plugin': plugin,
+        # Admin read-only: system info
+        'searchlog': searchlog,
+        'joblog': joblog,
+        'searchlist': searchlist,
+        'crawlinfo': crawlinfo,
+        'failureurl': failureurl,
+        'logfile': logfile,
+        'backup': backup,
+        'maintenance': maintenance,
+        'configinfo': configinfo,
         # 'integration': integration,  # Uncomment to enable
     }
 
@@ -134,6 +161,13 @@ def get_modules_to_run() -> List[Any]:
             search_pagination, search_facet, search_sort,
             search_thumbnail, search_suggest, search_related,
             popularWord,
+            # Admin read-only: general
+            pagedesign, storage, plugin,
+            # Admin read-only: system info (data-independent structural first)
+            configinfo, logfile,
+            crawlinfo, joblog, failureurl,
+            searchlog, searchlist,
+            backup, maintenance,
         ]
     else:
         # Parse comma-separated list of module names


### PR DESCRIPTION
## Summary
Fourth and final PR in the E2E coverage expansion series. Adds 12 admin read-only test modules covering system-info and general sub-pages — closing the admin-UI coverage gap from the original spec.

### New modules

**`src/fess/test/ui/admin/general/`** (3):
- `pagedesign.py` → `/admin/design/`
- `storage.py` → `/admin/storage/`
- `plugin.py` → `/admin/plugin/`

**`src/fess/test/ui/admin/sysinfo/`** (new directory, 9):
- `searchlog.py` → `/admin/searchlog/`
- `joblog.py` → `/admin/joblog/`
- `searchlist.py` → `/admin/searchlist/`
- `crawlinfo.py` → `/admin/crawlinginfo/`
- `failureurl.py` → `/admin/failureurl/`
- `logfile.py` → `/admin/log/`
- `backup.py` → `/admin/backup/`
- `maintenance.py` → `/admin/maintenance/`
- `configinfo.py` → `/admin/systeminfo/`

### Design
Read-only modules share a simple template: `goto` → `inner_text("body")` → assert at least one of 1-2 page-specific markers is present. Markers are chosen from `h1/h2/h3/legend/.card-title` content that does NOT appear in the shared sidebar nav (avoids false positives). No form fills, no button clicks — pages like `/admin/backup/` and `/admin/maintenance/` have destructive-looking controls but this test suite only verifies the page renders.

### main.py registration
All 12 modules registered in the three-place convention (import / `all_modules` / default-order list). New read-only modules placed at the end of the default order.

## Why
Completes the admin-sidebar coverage that started with PR-3's CRUD work. Together with PR-1 (seed infrastructure), PR-2 (search UI + popularWord rewrite), and PR-3 (admin CRUD), the module count grew from 18 at baseline to **50 modules**.

## Test plan
- [x] \`docker compose build test01\` succeeds
- [x] Each of the 12 modules passes as a stand-alone \`python -m ...\` invocation
- [x] Full \`./run_test.sh fess15 opensearch2\` — **50/50 modules pass** (38 from PR-3 + 12 new)
- [ ] CI weekly cron confirms green on Fess 15 × OpenSearch 2/3

## Notes / findings

1. **URL slug corrections** discovered during probing — Fess admin dir names don't match menu labels 1:1:
   - page design → \`/admin/design/\`
   - crawl info → \`/admin/crawlinginfo/\`
   - log file → \`/admin/log/\`
   - config info → \`/admin/systeminfo/\`
2. **Marker discipline**: generic sidebar strings (e.g., \`プラグイン\`, \`クローラー\`) appear on every admin page's nav. Each module's markers were picked from page-specific content (form labels, table headers, empty-state messages) to avoid false positives. For example, searchlog uses \`クエリーID\` and \`アクセスタイプ\` (form labels), not \`検索ログ\` (sidebar nav text).
3. **Implicit namespace packages**: \`admin/sysinfo/\` has no \`__init__.py\` — consistent with existing \`admin/general/\` and \`admin/dict/\`.

## Commits

13 commits on top of merged PR-3.