### PR TITLE
fix(test): force exact match on text= selectors to avoid English label collisions

### DIFF
--- a/src/fess/test/ui/admin/dict/mapping/delete.py
+++ b/src/fess/test/ui/admin/dict/mapping/delete.py
@@ -54,7 +54,9 @@ def run(context: FessContext) -> None:
 
     # Click text=[二]
     logger.info("Step 5: Open entry details")
-    page.click(f"text={label_name}")
+    # The list cell renders `data.inputs` (a List) via List.toString(), so a
+    # single input shows as `[label_name]` with literal brackets.
+    page.click(f"text=[{label_name}]")
     assert_startswith(
         page.url, context.url("/admin/dict/mapping/details/bWFwcGluZy50eHQ%3D/4/"))
 

--- a/src/fess/test/ui/admin/dict/mapping/update.py
+++ b/src/fess/test/ui/admin/dict/mapping/update.py
@@ -54,7 +54,9 @@ def run(context: FessContext) -> None:
 
     # Click text=[一]
     logger.info("Step 5: Open entry details")
-    page.click(f"text={label_name}")
+    # The list cell renders `data.inputs` (a List) via List.toString(), so a
+    # single input shows as `[label_name]` with literal brackets.
+    page.click(f"text=[{label_name}]")
     assert_startswith(
         page.url, context.url("/admin/dict/mapping/details/bWFwcGluZy50eHQ%3D/4/"))
 

--- a/src/fess/test/ui/admin/dict/synonym/delete.py
+++ b/src/fess/test/ui/admin/dict/synonym/delete.py
@@ -42,7 +42,9 @@ def run(context: FessContext) -> None:
     # Click on the entry created/updated by previous tests (find by label name)
     logger.info("Step 4: Click on existing entry to view details")
     label_name: str = context.create_label_name()
-    page.click(f"text={label_name}")
+    # The list cell renders `data.inputs` (a List) via List.toString(), so a
+    # single input shows as `[label_name]` with literal brackets.
+    page.click(f"text=[{label_name}]")
 
     # Click text=削除
     logger.info("Step 5: Click delete button")

--- a/src/fess/test/ui/admin/dict/synonym/update.py
+++ b/src/fess/test/ui/admin/dict/synonym/update.py
@@ -43,7 +43,9 @@ def run(context: FessContext) -> None:
 
     # Click on the entry created by add test (find by label name)
     logger.info("Step 4: Click on existing entry to view details")
-    page.click(f"text={label_name}")
+    # The list cell renders `data.inputs` (a List) via List.toString(), so a
+    # single input shows as `[label_name]` with literal brackets.
+    page.click(f"text=[{label_name}]")
 
     # Click text=編集
     logger.info("Step 5: Click edit button")

--- a/src/fess/test/ui/context.py
+++ b/src/fess/test/ui/context.py
@@ -19,6 +19,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _normalize_text_selector(selector: str) -> str:
+    """Convert `text=X` (substring match) to `text="X"` (exact match).
+
+    Playwright's `text=Foo` does case-insensitive substring matching, so a
+    selector like `text=Back` also matches `<p>Backup</p>`. Wrapping the
+    body in double quotes forces exact match. This avoids prefix collisions
+    in English (e.g. labels.crud_button_back="Back" vs labels.menu_backup=
+    "Backup") that don't surface in Japanese because 戻る and バックアップ
+    don't overlap.
+
+    Selectors that are already quoted, regex (`text=/.../`), use a different
+    engine (`button:has-text(...)`, CSS, attribute selectors), or chain via
+    `>>` (which intentionally uses substring matching to drill into a
+    container) are returned unchanged.
+    """
+    if not selector.startswith("text="):
+        return selector
+    if " >> " in selector:
+        return selector
+    body = selector[len("text="):]
+    if not body:
+        return selector
+    if body[0] in ('"', "'", '/'):
+        return selector
+    escaped = body.replace("\\", "\\\\").replace('"', '\\"')
+    return f'text="{escaped}"'
+
+
 class PageWrapper:
     """
     Wrapper for Playwright Page that adds logging to browser operations.
@@ -38,6 +66,7 @@ class PageWrapper:
 
     def click(self, selector: str, **kwargs) -> None:
         """Click an element with logging."""
+        selector = _normalize_text_selector(selector)
         self._logger.debug(f"[CLICK] selector='{selector}'")
         try:
             self._page.click(selector, **kwargs)
@@ -48,6 +77,7 @@ class PageWrapper:
 
     def fill(self, selector: str, value: str, **kwargs) -> None:
         """Fill an input field with logging."""
+        selector = _normalize_text_selector(selector)
         display_value = '***' if self._is_sensitive_field(selector) else self._truncate_value(value)
         self._logger.debug(f"[FILL] selector='{selector}' value='{display_value}'")
         try:
@@ -76,6 +106,7 @@ class PageWrapper:
 
     def wait_for_selector(self, selector: str, **kwargs) -> "ElementHandle":
         """Wait for a selector with logging."""
+        selector = _normalize_text_selector(selector)
         self._logger.debug(f"[WAIT_SELECTOR] selector='{selector}'")
         try:
             result = self._page.wait_for_selector(selector, **kwargs)
@@ -93,6 +124,7 @@ class PageWrapper:
 
     def inner_text(self, selector: str, **kwargs) -> str:
         """Get inner text with logging."""
+        selector = _normalize_text_selector(selector)
         self._logger.debug(f"[INNER_TEXT] selector='{selector}'")
         result = self._page.inner_text(selector, **kwargs)
         self._logger.debug(f"[INNER_TEXT] length={len(result)}")
@@ -100,6 +132,7 @@ class PageWrapper:
 
     def input_value(self, selector: str, **kwargs) -> str:
         """Get input value with logging."""
+        selector = _normalize_text_selector(selector)
         self._logger.debug(f"[INPUT_VALUE] selector='{selector}'")
         result = self._page.input_value(selector, **kwargs)
         display_result = '***' if self._is_sensitive_field(selector) else self._truncate_value(result)
@@ -108,6 +141,7 @@ class PageWrapper:
 
     def select_option(self, selector: str, value=None, **kwargs):
         """Select option with logging."""
+        selector = _normalize_text_selector(selector)
         self._logger.debug(f"[SELECT_OPTION] selector='{selector}' value='{value}'")
         try:
             result = self._page.select_option(selector, value, **kwargs)

--- a/tests/ui/test_normalize_text_selector.py
+++ b/tests/ui/test_normalize_text_selector.py
@@ -1,0 +1,68 @@
+"""Unit tests for `_normalize_text_selector`.
+
+Background: Playwright's `text=Back` does case-insensitive substring match,
+so it picks up `<p>Backup</p>` as well as the actual Back button. The English
+labels `crud_button_back="Back"` and `menu_backup="Backup"` collide. Quoting
+(`text="Back"`) forces exact match and resolves the collision.
+
+The helper rewrites unquoted `text=...` selectors to the quoted form, leaves
+already-quoted, regex, and non-text selectors alone, and preserves chained
+selectors (`text=X >> css=...`).
+"""
+from fess.test.ui.context import _normalize_text_selector
+
+
+def test_quotes_unquoted_text_selector():
+    assert _normalize_text_selector("text=Back") == 'text="Back"'
+
+
+def test_leaves_already_double_quoted_alone():
+    assert _normalize_text_selector('text="Back"') == 'text="Back"'
+
+
+def test_leaves_already_single_quoted_alone():
+    assert _normalize_text_selector("text='Back'") == "text='Back'"
+
+
+def test_leaves_regex_text_alone():
+    assert _normalize_text_selector("text=/^Back$/") == "text=/^Back$/"
+
+
+def test_leaves_non_text_selector_alone():
+    assert _normalize_text_selector('button:has-text("Back")') == 'button:has-text("Back")'
+    assert _normalize_text_selector('[placeholder="ユーザー名"]') == '[placeholder="ユーザー名"]'
+    assert _normalize_text_selector("input[name=\"name\"]") == "input[name=\"name\"]"
+
+
+def test_leaves_chained_selector_alone():
+    """Chained `text=X >> ...` selectors deliberately use substring matching
+    (e.g. `text=キャンセル 削除 >> button[name="delete"]` finds a dialog
+    containing both words and then drills into a button). Forcing exact match
+    here would break the query, so leave chained selectors untouched.
+    """
+    assert (
+        _normalize_text_selector('text=キャンセル 削除 >> button[name="delete"]')
+        == 'text=キャンセル 削除 >> button[name="delete"]'
+    )
+
+
+def test_handles_japanese_label():
+    assert _normalize_text_selector("text=戻る") == 'text="戻る"'
+
+
+def test_handles_label_with_spaces():
+    assert _normalize_text_selector("text=Bad Words") == 'text="Bad Words"'
+
+
+def test_handles_label_with_slash():
+    """labels.menu_data = 'Backup/Restore' — slashes must survive quoting."""
+    assert _normalize_text_selector("text=Backup/Restore") == 'text="Backup/Restore"'
+
+
+def test_escapes_embedded_double_quote():
+    """If a label literally contains a `"`, escape it to keep the wrapping valid."""
+    assert _normalize_text_selector('text=Say "hi"') == 'text="Say \\"hi\\""'
+
+
+def test_empty_selector_unchanged():
+    assert _normalize_text_selector("") == ""


### PR DESCRIPTION
## Summary
- `TEST_LANG=en ./run_test.sh fessx opensearch3` halted at the first module because Playwright's `text=Back` is a case-insensitive **substring** match. It also resolved to `<p>Backup</p>` (`labels.menu_backup="Backup"`) and waited on a hidden menu item until timeout. Japanese never tripped because 戻る and バックアップ don't overlap.
- `PageWrapper` now rewrites unchained `text=X` to `text="X"` (exact match) before delegating to Playwright. Already-quoted, regex (`text=/.../`), chained (`text=X >> ...`), and non-text engines pass through unchanged — chained selectors deliberately rely on substring to drill into a containing element (e.g. `text=キャンセル 削除 >> button[name="delete"]`).
- The mapping/synonym dictionary list views render `data.inputs` (a `List`) via `List.toString()`, so a single input shows as `[label_name]` with literal brackets. Those update/delete tests were passing by accident under the old substring matching; updated them to click `text=[{label_name}]` so they still work under exact match.

## Test plan
- [x] `TEST_LANG=en ./run_test.sh fessx opensearch3` — 60/60 passed (previously halted at module 1: `accesstoken`)
- [x] `pytest tests/` — 51/51 passed (incl. 11 new selector-normalization tests)
- [x] `TEST_LANG=ja ./run_test.sh fessx opensearch3` — recommended sanity check before merge to confirm the rewrite is locale-neutral