### PR TITLE
fix(runner): probe /api/v1/health and extend startup wait

### DIFF
--- a/src/run.sh
+++ b/src/run.sh
@@ -2,14 +2,15 @@
 
 cd $(dirname $0)
 
+error_count=0
 while true ; do
-  status=$(curl -w '%{http_code}\n' -s -o /dev/null "${FESS_URL}")
+  status=$(curl -w '%{http_code}\n' -s -o /dev/null "${FESS_URL}/api/v1/health")
   if [[ x"${status}" = x200 ]] ; then
     break
   else
     error_count=$((error_count + 1))
   fi
-  if [[ ${error_count} -ge 60 ]] ; then
+  if [[ ${error_count} -ge 180 ]] ; then
     echo "Fess is not available."
     exit 1
   fi


### PR DESCRIPTION
## Summary
Make the Playwright runner's pre-flight wait loop more reliable when Fess takes a while to come up.

## Changes Made
- Poll `${FESS_URL}/api/v1/health` instead of the root URL so the runner waits for the application to actually be ready, not just for the servlet container to answer.
- Initialize `error_count=0` before the loop so the first iteration doesn't rely on an unset variable under `set -u`-style shells.
- Raise the retry ceiling from 60 to 180 (≈3 minutes at 1 s intervals) so cold-start Fess containers — especially the OpenSearch combinations — have enough time to finish bootstrapping.

## Testing
- Smoke-checked the script logic locally; behavior with a healthy Fess (200) is unchanged, only the timeout window and probed path differ.
- CI matrix runs (`run-fess*-opensearch*`) will exercise the new wait window end-to-end.

## Breaking Changes
- None. The script still exits 1 when Fess never becomes reachable, just after a longer window.

## Additional Notes
- `/api/v1/health` is the documented Fess health endpoint and returns 200 only once the app is up, which avoids the race where the root path is briefly served before search is ready.