### PR TITLE
chore(runner): build runner image on docker compose up

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -70,4 +70,4 @@ echo "Fess:   ${fess_name}"
 echo "Search: ${search_engine_name}"
 echo "TEST_LANG=${TEST_LANG} (resolved) TEST_LANG_SEED=${TEST_LANG_SEED:-<unset>}"
 
-docker compose ${docker_compose_files} up --abort-on-container-exit --exit-code-from test01
+docker compose ${docker_compose_files} up --build --abort-on-container-exit --exit-code-from test01


### PR DESCRIPTION
## Summary
Add `--build` to `docker compose up` in `run_test.sh` so the `test01` runner image is rebuilt whenever its Dockerfile or pinned dependencies change.

## Changes Made
- `run_test.sh`: append `--build` to the `docker compose up` invocation that launches the test stack.

## Testing
- Ran `./run_test.sh fess15 opensearch2` locally; compose now rebuilds the runner image before starting and exits with the test01 status as before.

## Breaking Changes
- None. Existing flags and exit-code behavior are preserved; the only effect is an upfront image build step (cached when nothing changed).

## Additional Notes
- Avoids the recurring footgun where edits to the runner Dockerfile or `requirements.txt` (e.g. Playwright bumps) silently went unused because compose reused a stale image. Cold runs will be slightly slower the first time after a Dockerfile change; subsequent runs hit the build cache.