### PR TITLE
fix(runner): bake labels into image for Jenkins DinD compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Build context whitelist: only ship what the image actually needs.
+# Without this, transient runtime artifacts (screenshots, traces, JSON
+# results) are sent on every `docker compose up --build`, slowing the
+# build and busting layer cache for unrelated changes.
+*
+
+!Dockerfile
+!requirements.txt
+!src/
+!labels/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r /tmp/requirements.txt
 
 COPY src /app
+# Bake the extracted Fess labels (populated by extract_labels.sh on the
+# host before `docker compose up --build`) into the image. Bind-mounting
+# ./labels via compose breaks under Jenkins Docker-in-Docker because the
+# host daemon cannot see paths inside the Jenkins container's workspace.
+COPY labels /labels
 WORKDIR /app
 
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,9 +9,10 @@ services:
       - "TEST_LANG=${TEST_LANG:-random}"
       - "TEST_LANG_SEED=${TEST_LANG_SEED:-}"
       - "TEST_MODULES=${TEST_MODULES:-all}"
-      - "FESS_LABEL_DIR=/labels"
-    volumes:
-      - "./labels:/labels:ro"
+    # Labels are baked into the image via Dockerfile (`COPY labels`);
+    # the runner reads them at the default /labels path. Bind-mounting
+    # was removed because it does not work under Jenkins Docker-in-Docker
+    # (host daemon cannot see Jenkins workspace paths).
     networks:
       - searchtestnet
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -29,8 +29,10 @@ docker_compose_files="${docker_compose_files} -f ${base_dir}/compose-${search_en
 
 # ----- Extract Fess labels for i18n test support --------------------------
 # Resolve the Fess image referenced by the chosen compose file and copy
-# fess_label_*.properties / fess_message_*.properties into ./labels/
-# (mounted into test01 by compose.yaml as /labels:ro).
+# fess_label_*.properties / fess_message_*.properties into ./labels/.
+# These are baked into the test01 image via Dockerfile (`COPY labels`)
+# during `docker compose up --build` below; bind-mounting was removed
+# because it does not work under Jenkins Docker-in-Docker.
 if ! command -v yq >/dev/null 2>&1 ; then
     echo "ERROR: yq is required (brew install yq)" >&2
     exit 1
@@ -70,4 +72,4 @@ echo "Fess:   ${fess_name}"
 echo "Search: ${search_engine_name}"
 echo "TEST_LANG=${TEST_LANG} (resolved) TEST_LANG_SEED=${TEST_LANG_SEED:-<unset>}"
 
-docker compose ${docker_compose_files} up --build --abort-on-container-exit --exit-code-from test01
+docker compose ${docker_compose_files} up --build --abort-on-container-exit --exit-code-from test01 --attach test01


### PR DESCRIPTION
## Summary
Bind-mounting `./labels:/labels:ro` from the host breaks under Jenkins Docker-in-Docker — the host daemon can't see paths inside the Jenkins container's workspace, so the runner starts with an empty `/labels` and i18n tests fall back to defaults. This change copies the extracted labels into the image at build time so the runner works the same on a workstation and under Jenkins DinD.

## Changes Made
- `Dockerfile`: `COPY labels /labels` so the runner image carries the extracted Fess label/message properties.
- `compose.yaml`: drop the `./labels:/labels:ro` bind mount and the `FESS_LABEL_DIR=/labels` env override (the runner already reads `/labels` by default).
- `.dockerignore` (new): whitelist only what the image needs (`Dockerfile`, `requirements.txt`, `src/`, `labels/`) so transient runtime artifacts (`screenshots/`, `traces/`, `test_results.json`, etc.) don't get sent on every `docker compose up --build`. Keeps the build context small and the layer cache stable.
- `run_test.sh`: refresh the comment block to reflect the new flow (labels are baked at build time, not bind-mounted) and add `--attach test01` so the runner's logs stream cleanly alongside `fesstest01` / `searchtest01`.

## Testing
- Local: `./run_test.sh fess15 opensearch2` — `extract_labels.sh` populates `./labels/`, `docker compose up --build` bakes them into the image, and the runner finds them at `/labels` as before.
- Verified the build context shrinks once `.dockerignore` is in place (no more `screenshots/` / `traces/` upload on rebuilds).

## Breaking Changes
None for normal usage. If anyone was relying on overriding `FESS_LABEL_DIR` via the bind mount, they now need to either rebuild the image with their own labels or set `FESS_LABEL_DIR` to a different path that they bind-mount themselves.

## Additional Notes
- Follow-up to #48 (`build runner image on docker compose up`); together they make the runner fully self-contained on Jenkins DinD.
- Worth a sanity check that the `.dockerignore` whitelist covers everything the image needs — if a future module starts loading files from a new top-level dir, it has to be added to the allowlist.