### PR TITLE
chore(deps): upgrade Fess to version 15.6.1

### DIFF
--- a/compose-fess15-al2023.yaml
+++ b/compose-fess15-al2023.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.0-al2023
+    image: ghcr.io/codelibs/fess:15.6.1-al2023
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15-noble.yaml
+++ b/compose-fess15-noble.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.0-noble
+    image: ghcr.io/codelibs/fess:15.6.1-noble
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15.yaml
+++ b/compose-fess15.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.0
+    image: ghcr.io/codelibs/fess:15.6.1
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"


### PR DESCRIPTION
## Summary
Bumps the Fess container image referenced by the test runner from 15.6.0 to 15.6.1 across all three fess15 compose variants.

## Changes Made
- `compose-fess15.yaml`: `ghcr.io/codelibs/fess:15.6.0` → `15.6.1`
- `compose-fess15-al2023.yaml`: `ghcr.io/codelibs/fess:15.6.0-al2023` → `15.6.1-al2023`
- `compose-fess15-noble.yaml`: `ghcr.io/codelibs/fess:15.6.0-noble` → `15.6.1-noble`

## Testing
- CI matrix (`run-fess15-*.yml`) will exercise the new image against opensearch2/opensearch3 on the next scheduled run; can also be triggered via `workflow_dispatch`.
- Locally verifiable with `./run_test.sh fess15 opensearch2` (and the al2023 / noble variants).

## Breaking Changes
- None expected — patch-level Fess upgrade.

## Additional Notes
- Follows the same pattern as #40 (15.5.x → 15.6.0).
- `compose-fessx*.yaml` variants are intentionally untouched since they pin a different release stream.