### PR TITLE
chore(deps): upgrade OpenSearch to version 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Automated UI testing suite for [Fess](https://fess.codelibs.org/) (Enterprise Se
 - **Testing Framework**: [Playwright](https://playwright.dev/) 1.56.0 with Python
 - **HTML Analysis**: [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/) for DOM parsing
 - **Containerization**: Docker & Docker Compose
-- **Search Engines**: OpenSearch 2.19.1, OpenSearch 3.3.0
+- **Search Engines**: OpenSearch 2.19.1, OpenSearch 3.7.0
 - **Fess Versions**: 15.3.2 (stable), snapshot builds
 - **Base Images**: Microsoft Playwright (Ubuntu Noble), CodeLibs Fess & OpenSearch
 
@@ -87,7 +87,7 @@ Automated UI testing suite for [Fess](https://fess.codelibs.org/) (Enterprise Se
 
 ### Search Engines
 - `opensearch2` - OpenSearch 2.19.1
-- `opensearch3` - OpenSearch 3.3.0
+- `opensearch3` - OpenSearch 3.7.0
 
 ## Configuration
 

--- a/compose-opensearch3.yaml
+++ b/compose-opensearch3.yaml
@@ -1,6 +1,6 @@
 services:
   searchtest01:
-    image: ghcr.io/codelibs/fess-opensearch:3.6.0
+    image: ghcr.io/codelibs/fess-opensearch:3.7.0
     container_name: searchtest01
     environment:
       - node.name=searchtest01


### PR DESCRIPTION
## Summary
Upgrade the OpenSearch 3.x test configuration from 3.6.0 to 3.7.0 so the `opensearch3` engine variant runs against the latest fess-opensearch image.

## Changes Made
- `compose-opensearch3.yaml`: bump `ghcr.io/codelibs/fess-opensearch` image from 3.6.0 to 3.7.0
- `README.md`: update the OpenSearch 3 version references (which still said 3.3.0) to 3.7.0

## Testing
- Confirmed `ghcr.io/codelibs/fess-opensearch:3.7.0` exists on ghcr.io
- Validated the layered compose configuration with `docker compose -f compose.yaml -f compose-fessx.yaml -f compose-opensearch3.yaml config`

## Breaking Changes
- None

## Additional Notes
- The `run-*-opensearch3` workflows will pick up the new image on their next scheduled run; a `workflow_dispatch` run can verify it sooner.