### PR TITLE
chore(deps): upgrade Fess to version 15.7.0

### DIFF
--- a/compose-fess15-al2023.yaml
+++ b/compose-fess15-al2023.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.1-al2023
+    image: ghcr.io/codelibs/fess:15.7.0-al2023
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15-noble.yaml
+++ b/compose-fess15-noble.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.1-noble
+    image: ghcr.io/codelibs/fess:15.7.0-noble
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"

--- a/compose-fess15.yaml
+++ b/compose-fess15.yaml
@@ -1,6 +1,6 @@
 services:
   fesstest01:
-    image: ghcr.io/codelibs/fess:15.6.1
+    image: ghcr.io/codelibs/fess:15.7.0
     container_name: fesstest01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://searchtest01:9200"


### PR DESCRIPTION
## Summary
Upgrade the Fess container image from `15.6.1` to `15.7.0` across the Fess 15 compose variants so the UI test suite runs against the latest Fess release.

## Changes Made
- `compose-fess15.yaml`: `ghcr.io/codelibs/fess:15.6.1` → `15.7.0`
- `compose-fess15-al2023.yaml`: `ghcr.io/codelibs/fess:15.6.1-al2023` → `15.7.0-al2023`
- `compose-fess15-noble.yaml`: `ghcr.io/codelibs/fess:15.6.1-noble` → `15.7.0-noble`

## Testing
- Covered by the existing end-to-end UI test matrix (`./run_test.sh fess15 <engine>` and the al2023/noble variants), which runs against the upgraded image.

## Breaking Changes
- None.

## Additional Notes
- Image-tag-only change; no test code or runner configuration was modified.