### PR TITLE
test(error): detect the request error path instead of pinning one spelling

### DIFF
--- a/src/fess/test/ui/search/error_pages.py
+++ b/src/fess/test/ui/search/error_pages.py
@@ -3,10 +3,17 @@ error/redirect.jsp actually sends users to.
 
 Fess maps errors to views in two hops: web.xml points the container's error
 pages at error/redirect.jsp, which sendRedirect()s to an /error/* action by
-`type`. Two of those redirect targets do not resolve to any action (see
-_assert_badrequest_falls_through_to_notfound below); this module encodes
-where users land TODAY so that fixing the mismatch is a deliberate, visible
-change rather than a silent one.
+`type`. Not every redirect target resolves to an action, and where a target
+does not, the user silently lands on the Not Found view instead of the view
+the branch names; this module pins where users actually land so that closing
+one of those gaps is a deliberate, visible change rather than a silent one.
+
+The suite runs against several Fess builds (README: 15.7.0 and snapshot), and
+the request error view is served at a different path depending on the build --
+/error/badrequrest/ on 15.7.0 and below, /error/badrequest/ on builds that
+have renamed the action. No version flag is plumbed to the runner, so which
+spelling is routed is detected at runtime and the assertion is the invariant
+that holds on either build; see _assert_exactly_one_request_error_path_renders.
 
 No HTTP status is asserted anywhere here: web.xml maps 404 to redirect.jsp,
 which sendRedirect()s to a page served as 200, so a redirect-following
@@ -29,14 +36,18 @@ logger = logging.getLogger(__name__)
 
 NOTFOUND_PATH = "/error/notfound/"
 
-# path -> label whose text only that view renders. Note the action class is
-# ErrorBadrequrestAction (sic), so /error/badrequrest/ is the real URL.
+# path -> label whose text only that view renders. The request error view is
+# not listed: its path is build-dependent, so it is resolved at runtime by
+# _assert_exactly_one_request_error_path_renders rather than named here.
 ERROR_VIEWS = (
     (NOTFOUND_PATH, Labels.PAGE_NOT_FOUND_TITLE),
     ("/error/systemerror/", Labels.SYSTEM_ERROR_TITLE),
     ("/error/busy/", Labels.BUSY_TITLE),
-    ("/error/badrequrest/", Labels.REQUEST_ERROR_TITLE),
 )
+
+# The two spellings of the request error path, exactly one of which is routed.
+# Order is irrelevant: the routed one is detected, never assumed.
+REQUEST_ERROR_PATHS = ("/error/badrequest/", "/error/badrequrest/")
 
 
 def setup(playwright: Playwright) -> FessContext:
@@ -55,8 +66,8 @@ def _assert_view_renders(page, context: FessContext, path: str, key: str) -> Non
     _goto(page, context, path)
 
     # Not a tautology: an /error/* path with no action behind it redirects to
-    # /error/notfound/ instead, which is exactly what /error/badrequest/ does
-    # below. This assertion is what tells the two cases apart.
+    # /error/notfound/ instead, which is exactly what the unrouted spelling of
+    # the request error path does below. This assertion tells the cases apart.
     assert_equal(urlparse(page.url).path, path,
                  f"{path} did not serve itself; landed on {page.url}")
 
@@ -78,8 +89,8 @@ def _assert_lands_on_notfound(page, context: FessContext, requested: str) -> Non
     landed = urlparse(page.url)
     assert_equal(landed.path, NOTFOUND_PATH,
                  f"expected {requested} to land on {NOTFOUND_PATH}, got {page.url}")
-    # redirect.jsp:31-33 URL-encodes the original request URI into ?url=.
-    # parse_qs does the decoding, not Playwright: page.url hands back the
+    # redirect.jsp's fall-through branch URL-encodes the original request URI
+    # into ?url=. parse_qs does the decoding, not Playwright: page.url returns the
     # percent-encoded form (%2F stays %2F), and parse_qs is what turns it back
     # into the original path. Do not "simplify" this into a substring test on
     # page.url -- that would be testing the encoded form by accident.
@@ -88,23 +99,55 @@ def _assert_lands_on_notfound(page, context: FessContext, requested: str) -> Non
     _assert_contains_marker(page, t(Labels.PAGE_NOT_FOUND_TITLE), page.url)
 
 
-def _assert_badrequest_falls_through_to_notfound(page, context: FessContext) -> None:
-    """error/redirect.jsp:19 sends the badRequest branch to /error/badrequest/,
-    but the action class is ErrorBad*requrest*Action, so the real URL is
-    /error/badrequrest/ and /error/badrequest/ resolves to nothing.
+def _serves_itself(page, context: FessContext, path: str) -> bool:
+    """True when an action is routed at `path`: a routed /error/* path stays put,
+    while an unrouted one is redirected away to the Not Found view."""
+    _goto(page, context, path)
+    return urlparse(page.url).path == path
 
-    The consequence is a real Fess bug: a genuine HTTP 400 takes the
-    badRequest branch and the user is shown the 404 page instead of the 400
-    page. This asserts today's behaviour, not the intended behaviour, so that
-    correcting the typo shows up here rather than passing unnoticed.
+
+def _assert_exactly_one_request_error_path_renders(page, context: FessContext) -> None:
+    """The request error view answers exactly one of REQUEST_ERROR_PATHS, and the
+    other spelling falls through to Not Found.
+
+    Which spelling is routed depends on the build, so it is detected rather than
+    pinned -- the same reason FessContext.api_search probes for /api/v2 instead
+    of reading a version flag:
+
+      * Fess <= 15.7.0 names the action ErrorBad*requrest*Action (sic), so the
+        view answers /error/badrequrest/ while error/redirect.jsp sends the
+        badRequest branch to the correctly spelled /error/badrequest/, which
+        resolves to nothing. That mismatch is a real Fess bug: a genuine HTTP
+        400 shows the user the 404 page rather than the request error page.
+      * Later builds rename the action to ErrorBadrequestAction, so the JSP and
+        the action agree and the misspelling is what resolves to nothing.
+
+    Asserting the exclusive-or covers both spellings on either build without
+    pinning a version, and still fails loudly if neither answers (the view went
+    unreachable) or if both appear to (the 404 fall-through itself broke).
     """
-    _assert_lands_on_notfound(page, context, "/error/badrequest/")
+    routed = [path for path in REQUEST_ERROR_PATHS
+              if _serves_itself(page, context, path)]
+    assert_equal(len(routed), 1,
+                 f"expected exactly one of {REQUEST_ERROR_PATHS} to serve the "
+                 f"request error view, got {routed}")
+
+    _assert_view_renders(page, context, routed[0], Labels.REQUEST_ERROR_TITLE)
+    unrouted = next(p for p in REQUEST_ERROR_PATHS if p != routed[0])
+    _assert_lands_on_notfound(page, context, unrouted)
 
 
 def _assert_error_system_falls_through_to_notfound(page, context: FessContext) -> None:
-    """error/redirect.jsp:28 sends the badAuth branch to /error/system, but no
-    ErrorSystemAction exists (the view is served by /error/systemerror/), so
-    that path resolves to nothing either. Same reasoning as above."""
+    """No ErrorSystemAction exists in the default JSP mode -- the view is served
+    by /error/systemerror/ -- so /error/system resolves to nothing and lands on
+    Not Found.
+
+    This navigates to the path directly, so it holds on every build. What it is
+    worth varies: on builds whose error/redirect.jsp sends the badAuth branch to
+    /error/system it pins a real fall-through (a bad authentication shows the 404
+    page), while on builds that point that branch elsewhere nothing reaches this
+    path from redirect.jsp any more and the check is only a guard that no
+    ErrorSystemAction has appeared. Kept for the older builds in the matrix."""
     _goto(page, context, "/error/system?message_key=errors.bad_authentication")
     assert_equal(urlparse(page.url).path, NOTFOUND_PATH,
                  f"expected /error/system to land on {NOTFOUND_PATH}, got {page.url}")
@@ -124,7 +167,7 @@ def run(context: FessContext) -> None:
     for path, key in ERROR_VIEWS:
         _assert_view_renders(page, context, path, key)
 
-    _assert_badrequest_falls_through_to_notfound(page, context)
+    _assert_exactly_one_request_error_path_renders(page, context)
     _assert_error_system_falls_through_to_notfound(page, context)
     _assert_unknown_path_lands_on_notfound(page, context)
 


### PR DESCRIPTION
The error-page suite pinned `/error/badrequrest/` as the request error view's
URL. That spelling is correct only for Fess 15.7.0 and below, whose action
class is `ErrorBadrequrestAction` (sic). codelibs/fess#3188 renames it to
`ErrorBadrequestAction`, which moves the view to `/error/badrequest/` and
inverts both of this module's assertions on snapshot builds.

Since the suite runs 15.7.0 and snapshot side by side, neither spelling can be
hard-coded. No version flag is plumbed to the runner, so this detects which
spelling is routed at runtime -- the same approach `FessContext` already uses
to probe for `/api/v2` before falling back to v1 -- and asserts the invariant
that holds on either build: exactly one spelling serves the view, and the other
falls through to Not Found.

That keeps both spellings covered on both builds, and still fails loudly in the
two cases that matter: neither spelling answers (the view became unreachable),
or both appear to (the Not Found fall-through itself broke).

Also refreshes prose that #3188 makes stale: the module docstring, and
`_assert_error_system_falls_through_to_notfound`, whose assertion still holds on
every build but which stops pinning redirect.jsp's badAuth branch once that
branch points elsewhere.

Verified without running the suite (its container names are unnamespaced):
`pytest tests/` 93 passed, `py_compile` clean.
